### PR TITLE
Fix map not being usable during mission playback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,6 @@ function App() {
     // "Linear Acceleration": <LineChart telemetryData={telemetryData.linear_acceleration_rel} xDataKey="mission_time" yDataKey="magnitude" />,
     "Angular Velocity": <MultiLineChart telemetryData={telemetryData.angular_velocity} />,
   };
-console.log(telemetryData.coordinates.latitude)
   return (
     <div className="App">
       <TopBar


### PR DESCRIPTION
This PR fixes a bug where the map on the ground-station snaps back to its original position constantly during mission playback. This is because while a mission is being played back and the ground-station-ui receives data, its components are continually being re-rendered.

The map is never re-rendered, it just pulls and renders different images from the tiling server but re-rendering it causes it to snap back to its original center position, which we don't want. 

This PR refactors the polyline element - the only thing we want re-rendered - into a separate container that gets rendered separately from the map. That way, as the CoordinateMap component receives new data, it immediately passes them to the polyline container which does its own re-rendering. The changes also memoize the map.