### PR TITLE
Fix coordinates not being put on map correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,7 @@ function App() {
         isEditorModeOn={false} // Change this to manage edit mode
         componentMap={componentMap}
       />
-      <CoordinatesMap latitude={telemetryData.coordinates.latitude[0]} longitude={telemetryData.coordinates.longitude[0]} />
+      <CoordinatesMap latitude={telemetryData.coordinates.latitude.at(-1) || undefined} longitude={telemetryData.coordinates.longitude.at(-1) || undefined} />
 
       <button
         onClick={() => sendCommand("telemetry replay play TestData")}

--- a/src/components/charts/CoordinatesMap.tsx
+++ b/src/components/charts/CoordinatesMap.tsx
@@ -23,8 +23,12 @@ locations.set("carleton", [
 ] as LatLngExpression);
 
 interface CoordinatesMapProps {
-  latitude: number;
-  longitude: number;
+  latitude: number | undefined;
+  longitude: number | undefined;
+}
+interface PolylineProps {
+  latitude: number | undefined;
+  longitude: number | undefined;
 }
 
 function SnapToLocation({ val }: { val: string }) {
@@ -40,7 +44,7 @@ function SnapToLocation({ val }: { val: string }) {
 
 // Container that only rerenders polyline when coordinates change
 const PolylineContainer = React.memo(
-  ({ latitude, longitude }: { latitude: number; longitude: number }) => {
+  ({ latitude, longitude }: PolylineProps) => {
     const coordinatesRef = useRef<[number, number][]>([]);
 
     useEffect(() => {
@@ -59,7 +63,7 @@ const PolylineContainer = React.memo(
 
     return (
       <Polyline
-        pathOptions={{ color: "red" }}
+        pathOptions={{ color: "#232db0", weight: 5 }}
         positions={memoizedCoordinates}
       />
     );


### PR DESCRIPTION
Closes #10 

This PR adds a fix where coordinates weren't being put on the map because the data being sent to the map was always the first element of the array, not the last. It also makes the line a bit thicker and a different colour.