### PR TITLE
Add Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-debug.log*
 yarn-error.log*
 
 mapping_tiles
+
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:20 AS installer
+
+COPY package.json ./
+COPY tsconfig.json ./
+
+RUN npm install
+
+FROM node:20
+
+WORKDIR /app
+
+COPY --from=installer node_modules ./node_modules
+COPY package.json ./
+COPY tsconfig.json ./
+COPY public/ ./public
+COPY src/ ./src
+
+CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,30 @@
-FROM node:20 AS installer
+FROM node:20-alpine AS installer
 
 COPY package.json ./
 COPY tsconfig.json ./
 
+# Solution obtained from https://github.com/oven-sh/bun/issues/5545#issuecomment-1722461083
+# Add dependencies to get Bun working on Alpine
+RUN apk --no-cache add ca-certificates wget
+
+# Install glibc to run Bun
+RUN if [[ $(uname -m) == "aarch64" ]] ; \
+    then \
+    # aarch64
+    wget https://raw.githubusercontent.com/squishyu/alpine-pkg-glibc-aarch64-bin/master/glibc-2.26-r1.apk ; \
+    apk add --no-cache --allow-untrusted --force-overwrite glibc-2.26-r1.apk ; \
+    rm glibc-2.26-r1.apk ; \
+    else \
+    # x86_64
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk ; \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub ; \
+    apk add --no-cache --force-overwrite glibc-2.28-r0.apk ; \
+    rm glibc-2.28-r0.apk ; \
+    fi
+
 RUN npm install
 
-FROM node:20
+FROM node:20-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR dockerizes the ground-station frontend. 

By splitting the build into two stages (one for installing node modules + bun and one for executing), the size of the resulting docker image is miniscule

The plan is to use this in order to implement a new way of running the whole ground station using docker compose, as a result the mapping_tiles.zip file is being removed from this repo and will be put in a separate repo for the tiling server (also it's the old one that's not as good)