### PR TITLE
Migrate dockerfile over to bun:canary-alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,21 @@
-FROM node:20-alpine AS installer
+# FROM node:20-alpine AS installer
+FROM oven/bun:canary-alpine AS installer
 
 COPY package.json ./
 COPY tsconfig.json ./
 
-# Solution obtained from https://github.com/oven-sh/bun/issues/5545#issuecomment-1722461083
-# Add dependencies to get Bun working on Alpine
-RUN apk --no-cache add ca-certificates wget
+# RUN npm install -g bun 
+RUN bun install
 
-# Install glibc to run Bun
-RUN if [[ $(uname -m) == "aarch64" ]] ; \
-    then \
-    # aarch64
-    wget https://raw.githubusercontent.com/squishyu/alpine-pkg-glibc-aarch64-bin/master/glibc-2.26-r1.apk ; \
-    apk add --no-cache --allow-untrusted --force-overwrite glibc-2.26-r1.apk ; \
-    rm glibc-2.26-r1.apk ; \
-    else \
-    # x86_64
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk ; \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub ; \
-    apk add --no-cache --force-overwrite glibc-2.28-r0.apk ; \
-    rm glibc-2.28-r0.apk ; \
-    fi
-
-RUN npm install
-
-FROM node:20-alpine
+# FROM node:20-alpine
+FROM oven/bun:canary-alpine
 
 WORKDIR /app
 
-COPY --from=installer node_modules ./node_modules
+COPY --from=installer /home/bun/app/node_modules ./node_modules
 COPY package.json ./
 COPY tsconfig.json ./
 COPY public/ ./public
 COPY src/ ./src
 
-CMD ["npm", "run", "start"]
+CMD ["bun", "start"]


### PR DESCRIPTION
This PR migrates the ground-station-ui dockerfile to use the official oven/bun image rather than the node image