### PR TITLE
Fix live map snapping to location whenever long and lat coords update

### DIFF
--- a/src/components/charts/CoordinatesMap.tsx
+++ b/src/components/charts/CoordinatesMap.tsx
@@ -36,11 +36,16 @@ function SnapToLocation({ val }: { val: string }) {
   const location =
     locations.get(val) ||
     (locations.get("spaceport_america") as LatLngExpression);
-  map.setView(location, map.getZoom(), {
-    animate: true,
-  });
+  if (locChanged){
+    locChanged = false
+    map.setView(location, map.getZoom(), {
+      animate: true,
+    });
+  }
   return null;
 }
+
+let locChanged = false
 
 // Container that only rerenders polyline when coordinates change
 const PolylineContainer = React.memo(
@@ -83,6 +88,7 @@ const CoordinatesMap = ({ latitude, longitude }: CoordinatesMapProps) => {
           id="ports"
           className="styled-select"
           onChange={(e) => {
+            locChanged = true
             setCurrentLocation(e.target.value);
           }}
         >


### PR DESCRIPTION
This PR fixes a bug where when playing back a recording, the map component snaps back to it's last snapped point (selected from the drop down). This is because the component re renders whenever a new coordinate is sent. The simple fix was to just have the map snap to a new location whenever a new location is selected.