### PR TITLE
Adding light mode + switch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-leaflet": "^4.2.1",
         "react-resizable-panels": "^2.0.13",
         "react-scripts": "5.0.1",
+        "react-switch": "^7.1.0",
         "serve": "^14.2.3",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -16639,6 +16640,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-switch": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-7.1.0.tgz",
+      "integrity": "sha512-4xVeyImZE8QOTDw2FmhWz0iqo2psoRiS7XzdjaZBCIP8Dzo3rT0esHUjLee5WsAPSFXWWl1eVA5arp9n2C6yQA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-use-measure": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-leaflet": "^4.2.1",
     "react-resizable-panels": "^2.0.13",
     "react-scripts": "5.0.1",
+    "react-switch": "^7.1.0",
     "serve": "^14.2.3",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/components/CommandLine/CommandLine.css
+++ b/src/components/CommandLine/CommandLine.css
@@ -17,6 +17,10 @@
   color: var(--text-color);
 }
 
+.command-input::placeholder {
+  color: var(--text-color-secondary);
+}
+
 .command-input:focus {
   outline: none;
   border-color: var(--blue-color);

--- a/src/components/card/Card.css
+++ b/src/components/card/Card.css
@@ -13,7 +13,7 @@
   justify-content: space-between;
   align-items: center;
   height: 20px;
-  color: white;
+  color: var(--text-color);
   padding: 15px;
 }
 

--- a/src/components/charts/HumidityGauge.tsx
+++ b/src/components/charts/HumidityGauge.tsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import GaugeComponent from 'react-gauge-component';
 
 interface HumidityGaugeProps {
-    humidity: number;
+  humidity: number;
 }
-function HumidityGauge({humidity}: HumidityGaugeProps) {
+function HumidityGauge({ humidity }: HumidityGaugeProps) {
   return (
     <GaugeComponent
       type="semicircle"
@@ -14,22 +14,22 @@ function HumidityGauge({humidity}: HumidityGaugeProps) {
         cornerRadius: 1,
         gradient: true,
         subArcs: [
-            {
-                limit: 25,
-                color: '#bde7ff',
-                showTick: true
-              },
-              {
-                limit: 50,
-                color: '#6bb9fb',
-                showTick: true
-              },
-              {
-                limit: 75,
-                color: '#1a86f5',
-                showTick: true
-              },
-              { color: '#004de3' }
+          {
+            limit: 25,
+            color: '#bde7ff',
+            showTick: true
+          },
+          {
+            limit: 50,
+            color: '#6bb9fb',
+            showTick: true
+          },
+          {
+            limit: 75,
+            color: '#1a86f5',
+            showTick: true
+          },
+          { color: '#004de3' }
         ]
       }}
       pointer={{
@@ -38,17 +38,27 @@ function HumidityGauge({humidity}: HumidityGaugeProps) {
         width: 15,
       }}
       labels={{
-        valueLabel: { formatTextValue: value => value + '% (RH)' },
+        valueLabel: {
+          formatTextValue: value => value + '% (RH)',
+          style: { fill: "var(--text-color)", textShadow: "none" }
+        },
         tickLabels: {
           type: 'outer',
-        //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
+          //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
           ticks: [
             { value: 25 },
             { value: 50 },
             { value: 75 },
           ],
-        }
-      }}
+          defaultTickLineConfig: {
+            color: "var(--text-color-secondary)"
+          },
+          defaultTickValueConfig: {
+            style: { fill: "var(--text-color-secondary)", textShadow: "none" }
+          }
+        },
+      }
+      }
       value={humidity}
       minValue={0}
       maxValue={100}

--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -75,17 +75,17 @@ function LineChart<T extends { [key: string]: number[] }>({
               />
               <AxisLeft
                 scale={yScale}
-                stroke="var(--text-dark-color)"
-                tickStroke="var(--text-dark-color)"
+                stroke="var(--text-color-secondary)"
+                tickStroke="var(--text-color-secondary)"
                 tickLabelProps={() => ({
-                  fill: "var(--text-dark-color)",
+                  fill: "var(--text-color-secondary)",
                   fontSize: 11,
                   textAnchor: 'end',
                   dy: '0.33em',
                 })}
                 label={String(yDataKey)}
                 labelProps={{
-                  fill: "var(--text-dark-color)",
+                  fill: "var(--text-color-secondary)",
                   fontSize: 12,
                   textAnchor: 'middle',
                 }}
@@ -93,16 +93,16 @@ function LineChart<T extends { [key: string]: number[] }>({
               <AxisBottom
                 top={yMax}
                 scale={xScale}
-                stroke="var(--text-dark-color)"
-                tickStroke="var(--text-dark-color)"
+                stroke="var(--text-color-secondary)"
+                tickStroke="var(--text-color-secondary)"
                 tickLabelProps={() => ({
-                  fill: "var(--text-dark-color)",
+                  fill: "var(--text-color-secondary)",
                   fontSize: 11,
                   textAnchor: 'middle',
                 })}
                 label={String(xDataKey)}
                 labelProps={{
-                  fill: "var(--text-dark-color)",
+                  fill: "var(--text-color-secondary)",
                   fontSize: 12,
                   textAnchor: 'middle',
                 }}

--- a/src/components/charts/MultiLineChart.tsx
+++ b/src/components/charts/MultiLineChart.tsx
@@ -149,17 +149,17 @@ function MultiLineChart({ telemetryData }: MultiLineChartProps) {
                 )}
                 <AxisLeft
                   scale={yScale}
-                  stroke="var(--text-dark-color)"
-                  tickStroke="var(--text-dark-color)"
+                  stroke="var(--text-color-secondary)"
+                  tickStroke="var(--text-color-secondary)"
                   tickLabelProps={() => ({
-                    fill: "var(--text-dark-color)",
+                    fill: "var(--text-color-secondary)",
                     fontSize: 11,
                     textAnchor: "end",
                     dy: "0.33em",
                   })}
                   label="Values"
                   labelProps={{
-                    fill: "var(--text-dark-color)",
+                    fill: "var(--text-color-secondary)",
                     fontSize: 12,
                     textAnchor: "middle",
                   }}
@@ -167,16 +167,16 @@ function MultiLineChart({ telemetryData }: MultiLineChartProps) {
                 <AxisBottom
                   top={yMax}
                   scale={xScale}
-                  stroke="var(--text-dark-color)"
-                  tickStroke="var(--text-dark-color)"
+                  stroke="var(--text-color-secondary)"
+                  tickStroke="var(--text-color-secondary)"
                   tickLabelProps={() => ({
-                    fill: "var(--text-dark-color)",
+                    fill: "var(--text-color-secondary)",
                     fontSize: 11,
                     textAnchor: "middle",
                   })}
                   label="Mission Time"
                   labelProps={{
-                    fill: "var(--text-dark-color)",
+                    fill: "var(--text-color-secondary)",
                     fontSize: 12,
                     textAnchor: "middle",
                   }}

--- a/src/components/charts/PressureGauge.tsx
+++ b/src/components/charts/PressureGauge.tsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import GaugeComponent from 'react-gauge-component';
 
 interface PressureGaugeProps {
-    pressure: number;
+  pressure: number;
 }
-function PressureGauge({pressure}: PressureGaugeProps) {
+function PressureGauge({ pressure }: PressureGaugeProps) {
   pressure = pressure / 1000
   return (
     <GaugeComponent
@@ -15,37 +15,37 @@ function PressureGauge({pressure}: PressureGaugeProps) {
         cornerRadius: 1,
         gradient: true,
         subArcs: [
-            {
-                limit: 70,
-                color: '#14ff3a',
-                showTick: true
-              },
-              {
-                limit: 80,
-                color: '#8ce200',
-                showTick: true
-              },
-              {
-                limit: 90,
-                color: '#bdc000',
-                showTick: true
-              },
-              {
-                limit: 100,
-                color: '#dd9b00',
-                showTick: true
-              },
-              {
-                limit: 110,
-                color: '#f56e00',
-                showTick: true
-              },
-              {
-                limit: 120,
-                color: '#ff3114',
-                showTick: true
-              },
-              { color: '#EA4228' }
+          {
+            limit: 70,
+            color: '#14ff3a',
+            showTick: true
+          },
+          {
+            limit: 80,
+            color: '#8ce200',
+            showTick: true
+          },
+          {
+            limit: 90,
+            color: '#bdc000',
+            showTick: true
+          },
+          {
+            limit: 100,
+            color: '#dd9b00',
+            showTick: true
+          },
+          {
+            limit: 110,
+            color: '#f56e00',
+            showTick: true
+          },
+          {
+            limit: 120,
+            color: '#ff3114',
+            showTick: true
+          },
+          { color: '#EA4228' }
         ]
       }}
       pointer={{
@@ -54,10 +54,13 @@ function PressureGauge({pressure}: PressureGaugeProps) {
         width: 15,
       }}
       labels={{
-        valueLabel: { formatTextValue: value => value + 'KPa' },
+        valueLabel: {
+          formatTextValue: value => value + 'KPa',
+          style: { fill: "var(--text-color)", textShadow: "none" }
+        },
         tickLabels: {
           type: 'outer',
-        //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
+          //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
           ticks: [
             { value: 70 },
             { value: 80 },
@@ -65,6 +68,12 @@ function PressureGauge({pressure}: PressureGaugeProps) {
             { value: 100 },
             { value: 110 },
           ],
+          defaultTickLineConfig: {
+            color: "var(--text-color-secondary)"
+          },
+          defaultTickValueConfig: {
+            style: { fill: "var(--text-color-secondary)", textShadow: "none" }
+          }
         }
       }}
       value={pressure}

--- a/src/components/charts/TemperatureGauge.tsx
+++ b/src/components/charts/TemperatureGauge.tsx
@@ -53,7 +53,6 @@ function TemperatureGauge({ temperature }: TemperatureGaugeProps) {
             },
             tickLabels: {
               type: 'outer',
-              //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
               ticks: [
                 { value: -6 },
                 { value: 8 },

--- a/src/components/charts/TemperatureGauge.tsx
+++ b/src/components/charts/TemperatureGauge.tsx
@@ -3,66 +3,75 @@ import React, { useState, useEffect } from 'react';
 import GaugeComponent from 'react-gauge-component';
 
 interface TemperatureGaugeProps {
-    temperature: number;
+  temperature: number;
 }
-function TemperatureGauge({temperature}: TemperatureGaugeProps) {
+function TemperatureGauge({ temperature }: TemperatureGaugeProps) {
   return (
     <ParentSize>
       {({ width, height }) => (
-            <GaugeComponent
-            // style={{width: '0.5vw', height: '0.5wv'}}
-              type="semicircle"
-              arc={{
-                width: 0.2,
-                padding: 0.005,
-                cornerRadius: 1,
-                gradient: true,
-                subArcs: [
-                    {
-                        limit: -6,
-                        color: '#5BE12C',
-                        showTick: true
-                      },
-                      {
-                        limit: 8,
-                        color: '#F5CD19',
-                        showTick: true
-                      },
-                      {
-                        limit: 22,
-                        color: '#F5CD19',
-                        showTick: true
-                      },
-                      {
-                        limit: 36,
-                        color: '#EA4228',
-                        showTick: true
-                      },
-                      { color: '#EA4228' }
-                ]
-              }}
-              pointer={{
-                color: '#000000',
-                length: 0.80,
-                width: 15,
-              }}
-              labels={{
-                valueLabel: { formatTextValue: value => value + 'ºC' },
-                tickLabels: {
-                  type: 'outer',
-                //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
-                  ticks: [
-                    { value: -6 },
-                    { value: 8 },
-                    { value: 22 },
-                    { value: 36 },
-                  ],
-                }
-              }}
-              value={temperature}
-              minValue={-20}
-              maxValue={50}
-            />
+        <GaugeComponent
+          // style={{width: '0.5vw', height: '0.5wv'}}
+          type="semicircle"
+          arc={{
+            width: 0.2,
+            padding: 0.005,
+            cornerRadius: 1,
+            gradient: true,
+            subArcs: [
+              {
+                limit: -6,
+                color: '#5BE12C',
+                showTick: true
+              },
+              {
+                limit: 8,
+                color: '#F5CD19',
+                showTick: true
+              },
+              {
+                limit: 22,
+                color: '#F5CD19',
+                showTick: true
+              },
+              {
+                limit: 36,
+                color: '#EA4228',
+                showTick: true
+              },
+              { color: '#EA4228' }
+            ]
+          }}
+          pointer={{
+            color: '#000000',
+            length: 0.80,
+            width: 15,
+          }}
+          labels={{
+            valueLabel: {
+              formatTextValue: value => value + 'ºC',
+              style: { fill: "var(--text-color)", textShadow: "none" }
+            },
+            tickLabels: {
+              type: 'outer',
+              //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
+              ticks: [
+                { value: -6 },
+                { value: 8 },
+                { value: 22 },
+                { value: 36 },
+              ],
+              defaultTickLineConfig: {
+                color: "var(--text-color-secondary)"
+              },
+              defaultTickValueConfig: {
+                style: { fill: "var(--text-color-secondary)", textShadow: "none" }
+              }
+            }
+          }}
+          value={temperature}
+          minValue={-20}
+          maxValue={50}
+        />
       )}
     </ParentSize>
   );

--- a/src/components/topbar/TopBar.css
+++ b/src/components/topbar/TopBar.css
@@ -4,36 +4,36 @@
     align-items: center;
     background-color: var(--lighter-background-color);
     padding: 10px 20px;
-  }
-  
-  .logo {
+}
+
+.logo {
     font-size: 1.5em;
     font-weight: bold;
-  }
-  
-  .info {
+}
+
+.info {
     display: flex;
     gap: 20px;
-  }
-  
-  .info-item {
+}
+
+.info-item {
     display: flex;
     flex-direction: column;
     align-items: center;
-  }
-  
-  .label {
+}
+
+.label {
     font-size: 0.8em;
     color: #ccc;
-  }
-  
-  .value {
+}
+
+.value {
     font-size: 1em;
     font-weight: bold;
-  }
-  
+}
 
-  .styled-select {
+
+.styled-select {
     background-color: var(--lighter-background-color);
     color: var(--text-color);
     border: 1px solid var(--border-color);
@@ -46,25 +46,29 @@
     -moz-appearance: none;
     height: 100%;
 
-  }
-  
-  .styled-select:hover {
+}
+
+.styled-select:hover {
     border-color: var(--red-color);
-  }
-  
-  .styled-option {
+}
+
+.styled-option {
     background-color: var(--background-color);
     color: var(--text-color);
-  }
-  
-  .styled-select:focus {
+}
+
+.styled-select:focus {
     outline: none;
     border-color: var(--blue-color);
-  }
+}
 
-  .logo-png {
+.logo-png {
     width: 70px;
     height: auto;
     background-color: white;
     border-radius: 6px;
+}
+
+.theme-switch {
+    margin-top: auto;
 }

--- a/src/components/topbar/TopBar.css
+++ b/src/components/topbar/TopBar.css
@@ -24,7 +24,7 @@
 
 .label {
     font-size: 0.8em;
-    color: #ccc;
+    color: var(--text-color-secondary);
 }
 
 .value {

--- a/src/components/topbar/TopBar.tsx
+++ b/src/components/topbar/TopBar.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import "./TopBar.css";
+import Switch from "react-switch";
 
 interface TopBarProps {
   spacecraft?: string;
@@ -61,9 +62,37 @@ function TopBar({
             ))}
           </select>
         </div>
+        <div className="theme-switch">
+          {ThemeSwitch()}
+        </div>
       </div>
     </div>
   );
+}
+
+function ThemeSwitch() {
+  const [isLightTheme, setIsLightTheme] = useState(true)
+
+  function handleSwitchChange() {
+    setIsLightTheme(!isLightTheme);
+    if (isLightTheme) {
+      document.documentElement.classList.add("light-mode");
+    }
+    else {
+      document.documentElement.classList.remove("light-mode");
+    }
+  }
+
+  return (
+    <Switch onChange={handleSwitchChange} checked={isLightTheme}
+      offColor="#00B5E2"
+      offHandleColor="#f7f749"
+      onColor="#265396"
+      onHandleColor="#ebe9bd"
+      uncheckedIcon={false}
+      checkedIcon={false}
+    />
+  )
 }
 
 export default TopBar;

--- a/src/components/topbar/TopBar.tsx
+++ b/src/components/topbar/TopBar.tsx
@@ -85,10 +85,19 @@ function ThemeSwitch() {
 
   return (
     <Switch onChange={handleSwitchChange} checked={isLightTheme}
-      offColor="#00B5E2"
-      offHandleColor="#f7f749"
-      onColor="#265396"
-      onHandleColor="#ebe9bd"
+      checkedHandleIcon={
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path d="M12 22C17.5228 22 22 17.5228 22 12C22 11.5373 21.3065 11.4608 21.0672 11.8568C19.9289 13.7406 17.8615 15 15.5 15C11.9101 15 9 12.0899 9 8.5C9 6.13845 10.2594 4.07105 12.1432 2.93276C12.5392 2.69347 12.4627 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#1C274C"></path> </g></svg>
+      }
+      uncheckedHandleIcon={
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path d="M12 3V4M12 20V21M4 12H3M6.31412 6.31412L5.5 5.5M17.6859 6.31412L18.5 5.5M6.31412 17.69L5.5 18.5001M17.6859 17.69L18.5 18.5001M21 12H20M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path> </g></svg>
+      }
+      // the following is a workaround to extract css variables and pass them
+      // as props because the Switch library only supports hex values
+      onColor={
+        window
+          .getComputedStyle(document.documentElement)
+          .getPropertyValue('--red-color')
+      }
       uncheckedIcon={false}
       checkedIcon={false}
     />

--- a/src/index.css
+++ b/src/index.css
@@ -59,16 +59,36 @@ code {
 }
 
 :root {
-  --background-color: #0E0E0E;
-  --lighter-background-color: #161616;
+  color-scheme: dark;
+  --background-color-light: #faf7f7;
+  --lighter-background-color-light: #ffffff;
+  --text-color-light: #000000;
+  --border-color-light: #ece3e3;
+  --border-hover-light: rgba(232, 33, 39, 0.5);
+
+  --background-color-dark: #0E0E0E;
+  --lighter-background-color-dark: #161616;
+  --text-color-dark: #FFFFFF;
+  --border-color-dark: rgba(255, 255, 255, 0.1);
+  --border-hover-dark: rgba(232, 33, 39, 0.5);
+
+  --background-color: light-dark(var(--background-color-light), var(--background-color-dark));
+  --lighter-background-color: light-dark(var(--lighter-background-color-light), var(--lighter-background-color-dark));
+  --text-color: light-dark(var(--text-color-light), var(--text-color-dark));
+  --border-color: light-dark(var(--border-color-light), var(--border-color-dark));
+  --border-hover: light-dark(var(--border-hover-light), var(--border-hover-dark));
+
   --red-color: #E82127;
   --green-color: #25CB55;
   --yellow-color: #FFBD0A;
   --blue-color: #007BE4;
-  --text-color: #FFFFFF;
   --text-dark-color: #8d8d8d;
-  --shadow-light: rgba(0, 0, 0, 0.1);
+
+  --shadow-small: rgba(0, 0, 0, 0.1);
   --shadow-medium: rgba(0, 0, 0, 0.06);
-  --border-color: rgba(255, 255, 255, 0.1);
-  --border-hover: rgba(232, 33, 39, 0.5);
+}
+
+
+.light-mode {
+  color-scheme: light;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -64,14 +64,14 @@ code {
   --lighter-background-color-light: #ffffff;
   --text-color-light: #000000;
   --border-color-light: #ece3e3;
-  --border-hover-light: rgba(232, 33, 39, 0.5);
+  --border-hover-light: rgba(232, 33, 40, 0.768);
   --text-color-secondary-light: #4e3f3f;
 
   --background-color-dark: #0E0E0E;
   --lighter-background-color-dark: #161616;
   --text-color-dark: #FFFFFF;
   --border-color-dark: rgba(255, 255, 255, 0.1);
-  --border-hover-dark: rgba(232, 33, 39, 0.5);
+  --border-hover-dark: rgba(232, 33, 40, 0.768);
   --text-color-secondary-dark: #8d8d8d;
 
   --background-color: light-dark(var(--background-color-light), var(--background-color-dark));

--- a/src/index.css
+++ b/src/index.css
@@ -65,24 +65,26 @@ code {
   --text-color-light: #000000;
   --border-color-light: #ece3e3;
   --border-hover-light: rgba(232, 33, 39, 0.5);
+  --text-color-secondary-light: #4e3f3f;
 
   --background-color-dark: #0E0E0E;
   --lighter-background-color-dark: #161616;
   --text-color-dark: #FFFFFF;
   --border-color-dark: rgba(255, 255, 255, 0.1);
   --border-hover-dark: rgba(232, 33, 39, 0.5);
+  --text-color-secondary-dark: #8d8d8d;
 
   --background-color: light-dark(var(--background-color-light), var(--background-color-dark));
   --lighter-background-color: light-dark(var(--lighter-background-color-light), var(--lighter-background-color-dark));
   --text-color: light-dark(var(--text-color-light), var(--text-color-dark));
   --border-color: light-dark(var(--border-color-light), var(--border-color-dark));
   --border-hover: light-dark(var(--border-hover-light), var(--border-hover-dark));
+  --text-color-secondary: light-dark(var(--text-color-secondary-light), var(--text-color-secondary-dark));
 
   --red-color: #E82127;
   --green-color: #25CB55;
   --yellow-color: #FFBD0A;
   --blue-color: #007BE4;
-  --text-dark-color: #8d8d8d;
 
   --shadow-small: rgba(0, 0, 0, 0.1);
   --shadow-medium: rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
Closes #66 
- react-switch dependency was installed for the toggle 
- dark/light mode logic integrated using the CSS "color-scheme" property
- most of the CSS variables remained untouched apart from "text-dark-color" which became "text-color-secondary"
- styling was added to external components such as the gauges