### PR TITLE
Gauge visual improvemenets

### DIFF
--- a/src/components/charts/HumidityGauge.tsx
+++ b/src/components/charts/HumidityGauge.tsx
@@ -7,12 +7,11 @@ interface HumidityGaugeProps {
 function HumidityGauge({ humidity }: HumidityGaugeProps) {
   return (
     <GaugeComponent
-      type="semicircle"
+      type="radial"
       arc={{
-        width: 0.2,
-        padding: 0.005,
-        cornerRadius: 1,
-        gradient: true,
+        width: 0.3,
+        padding: 0.01,
+        cornerRadius: 2,
         subArcs: [
           {
             limit: 25,

--- a/src/components/charts/PressureGauge.tsx
+++ b/src/components/charts/PressureGauge.tsx
@@ -7,79 +7,81 @@ interface PressureGaugeProps {
 function PressureGauge({ pressure }: PressureGaugeProps) {
   pressure = pressure / 1000
   return (
-    <GaugeComponent
-      type="semicircle"
-      arc={{
-        width: 0.2,
-        padding: 0.005,
-        cornerRadius: 1,
-        gradient: true,
-        subArcs: [
-          {
-            limit: 70,
-            color: '#14ff3a',
-            showTick: true
+    <div style={{ maxWidth: "100%", maxHeight: "100%", overflow: 'visible' }}>
+      <GaugeComponent
+        type="radial"
+        arc={{
+          width: 0.3,
+          padding: 0.01,
+          cornerRadius: 2,
+          subArcs: [
+            {
+              limit: 70,
+              color: '#14ff3a',
+              showTick: true
+            },
+            {
+              limit: 80,
+              color: '#8ce200',
+              showTick: true
+            },
+            {
+              limit: 90,
+              color: '#bdc000',
+              showTick: true
+            },
+            {
+              limit: 100,
+              color: '#dd9b00',
+              showTick: true
+            },
+            {
+              limit: 110,
+              color: '#f56e00',
+              showTick: true
+            },
+            {
+              limit: 120,
+              color: '#ff3114',
+              showTick: true
+            },
+            { color: '#EA4228' }
+          ]
+        }}
+        pointer={{
+          color: '#000000',
+          length: 0.80,
+          width: 15,
+        }}
+        labels={{
+          valueLabel: {
+            formatTextValue: value => value + 'KPa',
+            style: { fill: "var(--text-color)", textShadow: "none" }
           },
-          {
-            limit: 80,
-            color: '#8ce200',
-            showTick: true
-          },
-          {
-            limit: 90,
-            color: '#bdc000',
-            showTick: true
-          },
-          {
-            limit: 100,
-            color: '#dd9b00',
-            showTick: true
-          },
-          {
-            limit: 110,
-            color: '#f56e00',
-            showTick: true
-          },
-          {
-            limit: 120,
-            color: '#ff3114',
-            showTick: true
-          },
-          { color: '#EA4228' }
-        ]
-      }}
-      pointer={{
-        color: '#000000',
-        length: 0.80,
-        width: 15,
-      }}
-      labels={{
-        valueLabel: {
-          formatTextValue: value => value + 'KPa',
-          style: { fill: "var(--text-color)", textShadow: "none" }
-        },
-        tickLabels: {
-          type: 'outer',
-          //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
-          ticks: [
-            { value: 70 },
-            { value: 80 },
-            { value: 90 },
-            { value: 100 },
-            { value: 110 },
-          ],
-          defaultTickLineConfig: {
-            color: "var(--text-color-secondary)"
-          },
-          defaultTickValueConfig: {
-            style: { fill: "var(--text-color-secondary)", textShadow: "none" }
+          tickLabels: {
+            type: 'outer',
+            //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
+            ticks: [
+              { value: 70 },
+              { value: 80 },
+              { value: 90 },
+              { value: 100 },
+              { value: 110 },
+            ],
+            defaultTickLineConfig: {
+              color: "var(--text-color-secondary)"
+            },
+            defaultTickValueConfig: {
+              style: { fill: "var(--text-color-secondary)", textShadow: "none" }
+            }
           }
-        }
-      }}
-      value={pressure}
-      minValue={60}
-      maxValue={120}
-    />
+        }}
+        value={pressure}
+        minValue={60}
+        maxValue={120}
+      />
+
+    </div>
   );
 }
 

--- a/src/components/charts/TemperatureGauge.tsx
+++ b/src/components/charts/TemperatureGauge.tsx
@@ -11,31 +11,40 @@ function TemperatureGauge({ temperature }: TemperatureGaugeProps) {
       {({ width, height }) => (
         <GaugeComponent
           // style={{width: '0.5vw', height: '0.5wv'}}
-          type="semicircle"
+          type="radial"
           arc={{
-            width: 0.2,
-            padding: 0.005,
-            cornerRadius: 1,
-            gradient: true,
+            width: 0.3,
+            padding: 0.01,
+            cornerRadius: 2,
             subArcs: [
               {
-                limit: -6,
-                color: '#5BE12C',
+                limit: -5,
+                color: '#14ff3a',
                 showTick: true
               },
               {
-                limit: 8,
-                color: '#F5CD19',
+                limit: 10,
+                color: '#8ce200',
                 showTick: true
               },
               {
-                limit: 22,
-                color: '#F5CD19',
+                limit: 25,
+                color: '#bdc000',
                 showTick: true
               },
               {
-                limit: 36,
-                color: '#EA4228',
+                limit: 40,
+                color: '#dd9b00',
+                showTick: true
+              },
+              {
+                limit: 55,
+                color: '#f56e00',
+                showTick: true
+              },
+              {
+                limit: 70,
+                color: '#ff3114',
                 showTick: true
               },
               { color: '#EA4228' }
@@ -55,10 +64,11 @@ function TemperatureGauge({ temperature }: TemperatureGaugeProps) {
               type: 'outer',
               //   valueConfig: { formatTextValue: (value: string) => value + 'ºC', fontSize: 10 },
               ticks: [
-                { value: -6 },
-                { value: 8 },
-                { value: 22 },
-                { value: 36 },
+                { value: -5 },
+                { value: 10 },
+                { value: 25 },
+                { value: 40 },
+                { value: 55 },
               ],
               defaultTickLineConfig: {
                 color: "var(--text-color-secondary)"
@@ -70,7 +80,7 @@ function TemperatureGauge({ temperature }: TemperatureGaugeProps) {
           }}
           value={temperature}
           minValue={-20}
-          maxValue={50}
+          maxValue={70}
         />
       )}
     </ParentSize>


### PR DESCRIPTION
Idk why but the gauge svg clips outside the parent element. 
There was [issue](https://github.com/antoniolago/react-gauge-component/issues/38) in the gauge library repo that promised a fix in version 1.2.61. Updating to that version gave me ResizeObserver errors. So for now I give up.