### PR TITLE
Update UI to support magnetometer readings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM oven/bun:canary-slim
+LABEL AUTHOR="Elias Hawa"
 WORKDIR /app
 COPY package.json ./
 RUN bun install
 COPY . .
 RUN bun run build
-CMD ["bun", "run", "preview", "--host"]
+CMD ["bunx", "serve", "dist", "-p", "4173"]

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -123,43 +123,16 @@ function MapControls({ center }: { center: [number, number] }) {
 	);
 }
 
-interface AccelerationData {
-	mission_time: number[];
-	x: number[];
-	y: number[];
-	z: number[];
-}
-
 interface CoordinatesData {
+	mission_time: number[];
 	latitude: number[];
 	longitude: number[];
-	mission_time: number[];
-}
-
-interface TelemetryData {
-	last_mission_time?: number;
-	altitude_sea_level?: {
-		mission_time: number[];
-		metres: number[];
-		feet: number[];
-	};
-	altitude_launch_level?: {
-		mission_time: number[];
-		metres: number[];
-		feet: number[];
-	};
-	temperature?: { celsius: number[] };
-	pressure?: { pascals: number[] };
-	linear_acceleration_rel?: AccelerationData;
-	angular_velocity?: AccelerationData;
-	coordinates?: CoordinatesData;
-	[key: string]: unknown;
 }
 
 interface MapViewProps {
 	center?: [number, number];
 	zoom?: number;
-	telemetryData?: TelemetryData;
+	telemetryData?: CoordinatesData;
 	className?: string;
 	useLocalTiles?: boolean;
 }
@@ -179,8 +152,8 @@ function MapView({
 	const { pathPositions, addPathPosition } = useMapContext();
 
 	const position: [number, number] = React.useMemo(() => {
-		const latitude = telemetryData?.coordinates?.latitude;
-		const longitude = telemetryData?.coordinates?.longitude;
+		const latitude = telemetryData?.latitude;
+		const longitude = telemetryData?.longitude;
 
 		if (latitude && longitude && latitude.length > 0 && longitude.length > 0) {
 			// Get the latest coordinates
@@ -245,7 +218,7 @@ function MapView({
 				<Marker position={position} icon={customIcon}>
 					<Popup>
 						Current Position
-						{telemetryData?.coordinates && (
+						{telemetryData && (
 							<div>
 								<p>Lat: {position[0].toFixed(6)}</p>
 								<p>Lng: {position[1].toFixed(6)}</p>

--- a/src/components/TelemetryDashboard.tsx
+++ b/src/components/TelemetryDashboard.tsx
@@ -59,7 +59,7 @@ function TelemetryDashboard() {
 				<div className="flex-1 h-[calc(100%-3rem)] flex flex-col">
 					<h2 className="text-lg font-semibold mb-4">Location Map</h2>
 					<div className="flex-1">
-						<MapView telemetryData={telemetryData} />
+						<MapView telemetryData={telemetryData.gnss} />
 					</div>
 				</div>
 			)}

--- a/src/constants/websocket.ts
+++ b/src/constants/websocket.ts
@@ -71,10 +71,26 @@ export interface WebSocketData {
 			mission_time: number[];
 			percentage: number[];
 		};
-		coordinates: {
-			mission_time: number[];
-			latitude: number[];
-			longitude: number[];
-		};
+		gnss: {
+			mission_time: number[],
+			latitude: number[],
+			longitude: number[]
+		},
+		sats_in_use: {
+			mission_time: number[],
+			gps: [[], []],
+			glonass: [[], []]
+		},
+		voltage: {
+			[key: string]: number[];
+			mission_time: number[]
+		}
+		magnetic_field: {
+			mission_time: number[],
+			x: number[],
+			y: number[],
+			z: number[],
+			magnitude: number[],
+		}
 	};
 }


### PR DESCRIPTION
This PR updates the UI to support magnetometer readings from the backend. It also slightly changes how websocket data is received and parsed by the map component. Lastly, the Dockerfile was updated to use `bunx serve` which is apparently the better way of deploying a compiled vite application.