### PR TITLE
Modify UI widgets

### DIFF
--- a/src/components/TelemetryDashboard.tsx
+++ b/src/components/TelemetryDashboard.tsx
@@ -65,33 +65,14 @@ function TelemetryDashboard() {
 			)}
 
 			{activeTab === "dashboard" && (
-				<div className="grid grid-cols-1 md:grid-cols-4 xl:grid-cols-4 gap-6 h-full">
+				<div className="grid grid-cols-1 md:grid-cols-6 xl:grid-cols-6 gap-6 h-full">
 					{/* Full width items */}
-					<div className="md:col-span-2">
+					<div className="md:col-span-3">
 						<Card title="Altitude">
 							<GeneralMultiLineChart
 								telemetryData={telemetryData.altitude_launch_level}
 								xAxisLabel="Mission time (s)"
 								yAxisLabel="Altitude (m)"
-							/>
-						</Card>
-					</div>
-
-					<div className="md:col-span-2">
-						<Card title="Linear Acceleration">
-							<GeneralMultiLineChart
-								telemetryData={telemetryData.linear_acceleration}
-								xAxisLabel="Mission time (s)"
-								yAxisLabel="Linear Acceleration (m/s^2)"
-							/>
-						</Card>
-					</div>
-
-					<div className="md:col-span-2">
-						<Card title="Angular Velocity">
-							<GeneralMultiLineChart telemetryData={telemetryData.angular_velocity} 
-								xAxisLabel="Mission time (s)"
-								yAxisLabel="Angular Velocity (°/s)"
 							/>
 						</Card>
 					</div>
@@ -142,6 +123,34 @@ function TelemetryDashboard() {
 									/>
 								</div>
 							</div>
+						</Card>
+					</div>
+
+					<div className="md:col-span-2">
+						<Card title="Linear Acceleration">
+							<GeneralMultiLineChart
+								telemetryData={telemetryData.linear_acceleration}
+								xAxisLabel="Mission time (s)"
+								yAxisLabel="Linear Acceleration (m/s^2)"
+							/>
+						</Card>
+					</div>
+
+					<div className="md:col-span-2">
+						<Card title="Angular Velocity">
+							<GeneralMultiLineChart telemetryData={telemetryData.angular_velocity} 
+								xAxisLabel="Mission time (s)"
+								yAxisLabel="Angular Velocity (°/s)"
+							/>
+						</Card>
+					</div>
+
+					<div className="md:col-span-2">
+						<Card title="Magnetic Field Strength">
+							<GeneralMultiLineChart telemetryData={telemetryData.magnetic_field} 
+								xAxisLabel="Mission time (s)"
+								yAxisLabel="Micro Teslas (μT)"
+							/>
 						</Card>
 					</div>
 				</div>

--- a/src/components/TelemetryHeader.tsx
+++ b/src/components/TelemetryHeader.tsx
@@ -23,6 +23,18 @@ function TelemetryValue({ label, value }: TelemetryValueProps) {
 
 function TelemetryHeader({ onCommandOpen }: TelemetryHeaderProps) {
 	const { data } = useWebSocketContext();
+	let apogee: number = -1;
+
+	const getApogee = () => {
+		if (!data?.telemetry?.altitude_launch_level?.metres) return "No data";
+		const latestAltitude = data.telemetry.altitude_launch_level.metres[0];
+		if (latestAltitude === undefined){
+			return "No data"
+		} else {
+			apogee = Math.max(apogee, latestAltitude)
+			return apogee
+		}
+	}
 
 	const getAltitude = () => {
 		if (!data?.telemetry?.altitude_launch_level?.metres) return "No data";
@@ -79,6 +91,7 @@ function TelemetryHeader({ onCommandOpen }: TelemetryHeaderProps) {
 					/>
 					<TelemetryValue label="MISSION TIME" value={getMissionTime()} />
 					<TelemetryValue label="ALTITUDE" value={getAltitude()} />
+					<TelemetryValue label="APOGEE" value={getApogee()} />
 					<TelemetryValue label="INCLINATION" value="No data" />
 
 					{/* Console */}


### PR DESCRIPTION
Closes #53 

This PR moves around the widgets such that:
- Altitude and the three gauges we have (temp, pressure, humidity) are on the top row
- IMU sensor reading charts are grouped together on the bottom row

It also adds a field in the telem header for apogee