### PR TITLE
Telemetry dashboard fixes

### DIFF
--- a/src/components/TelemetryDashboard.tsx
+++ b/src/components/TelemetryDashboard.tsx
@@ -70,7 +70,7 @@ function TelemetryDashboard() {
 					<div className="md:col-span-3">
 						<Card title="Altitude">
 							<GeneralMultiLineChart
-								telemetryData={telemetryData.altitude_launch_level}
+								telemetryData={telemetryData.altitude_sea_level}
 								xAxisLabel="Mission time (s)"
 								yAxisLabel="Altitude (m)"
 							/>

--- a/src/components/TelemetryHeader.tsx
+++ b/src/components/TelemetryHeader.tsx
@@ -47,7 +47,7 @@ function TelemetryHeader({ onCommandOpen }: TelemetryHeaderProps) {
 
 	const getMissionTime = () => {
 		if (!data?.telemetry?.last_mission_time) return "No data";
-		return `T+${(data.telemetry.last_mission_time / 1000).toFixed(3)}s`;
+		return `T+${(data.telemetry.last_mission_time).toFixed(3)}s`;
 	};
 
 	const getAvailablePorts = () => {

--- a/src/components/charts/GeneralMultiLineChart.tsx
+++ b/src/components/charts/GeneralMultiLineChart.tsx
@@ -97,12 +97,13 @@ function GeneralMultiLineChart({
                     }))}
                     x={(d) => xScale(d.x)}
                     y={(d) => yScale(d.y)}
-                    stroke={lineColors[ind++]}
+                    stroke={lineColors[ind]}
                     strokeWidth={2}
                     curve={curveMonotoneX}
                   />
                 )
               );
+              ind++
             }
           );
 


### PR DESCRIPTION
This PR adds some small fixes to the telemetry dashboard, including:
- Having the altitude graph read from sea level instead of launch level (prob temp)
- Fixing last mission time reading
- Fixing colors on multiline graphs being determined by how many lines on the graph are visible