### PR TITLE
Have altitude and apogee header values read from sea level

### DIFF
--- a/src/components/TelemetryDashboard.tsx
+++ b/src/components/TelemetryDashboard.tsx
@@ -65,7 +65,7 @@ function TelemetryDashboard() {
 			<div style={{display: activeTab === "dashboard" ? "grid" : "none" }} className="grid grid-cols-1 md:grid-cols-6 xl:grid-cols-6 gap-6 h-full">
 				{/* Full width items */}
 				<div className="md:col-span-3">
-					<Card title="Altitude">
+					<Card title="Altitude (sea level)">
 						<GeneralMultiLineChart
 							telemetryData={telemetryData.altitude_sea_level}
 							xAxisLabel="Mission time (s)"

--- a/src/components/TelemetryHeader.tsx
+++ b/src/components/TelemetryHeader.tsx
@@ -22,24 +22,25 @@ function TelemetryValue({ label, value }: TelemetryValueProps) {
 	);
 }
 
+let apogee: number = -1;
+
 function TelemetryHeader({ onCommandOpen }: TelemetryHeaderProps) {
 	const { data } = useWebSocketContext();
-	let apogee: number = -1;
 
 	const getApogee = () => {
-		if (!data?.telemetry?.altitude_launch_level?.metres) return "No data";
-		const latestAltitude = data.telemetry.altitude_launch_level.metres[0];
+		if (!data?.telemetry?.altitude_sea_level?.metres) return "No data";
+		const latestAltitude = data.telemetry.altitude_sea_level.metres[data.telemetry.altitude_sea_level.metres.length - 1];
 		if (latestAltitude === undefined){
 			return "No data"
 		} else {
 			apogee = Math.max(apogee, latestAltitude)
-			return apogee
+			return `${apogee.toFixed(2)}m`
 		}
 	}
 
 	const getAltitude = () => {
-		if (!data?.telemetry?.altitude_launch_level?.metres) return "No data";
-		const latestAltitude = data.telemetry.altitude_launch_level.metres[0];
+		if (!data?.telemetry?.altitude_sea_level?.metres) return "No data";
+		const latestAltitude = data.telemetry.altitude_sea_level.metres[data.telemetry.altitude_sea_level.metres.length - 1];
 		return latestAltitude !== undefined
 			? `${latestAltitude.toFixed(2)}m`
 			: "No data";


### PR DESCRIPTION
This PR fixes the altitude and telemetry header values to read from the sea level field in the websocket dict.